### PR TITLE
Add unit tests for utility classes

### DIFF
--- a/app/src/test/java/ch/zhaw/pa_fs25/data/entity/CategoryExtensionsTest.kt
+++ b/app/src/test/java/ch/zhaw/pa_fs25/data/entity/CategoryExtensionsTest.kt
@@ -1,0 +1,23 @@
+package ch.zhaw.pa_fs25.data.entity
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CategoryExtensionsTest {
+    @Test
+    fun `getCategoryName returns correct name`() {
+        val categories = listOf(
+            Category(id = 1, name = "Food"),
+            Category(id = 2, name = "Travel")
+        )
+
+        assertEquals("Travel", categories.getCategoryName(2))
+    }
+
+    @Test
+    fun `getCategoryName returns Unknown for missing id`() {
+        val categories = listOf(Category(id = 1, name = "Food"))
+
+        assertEquals("Unknown", categories.getCategoryName(99))
+    }
+}

--- a/app/src/test/java/ch/zhaw/pa_fs25/util/SwissTransactionMapperTest.kt
+++ b/app/src/test/java/ch/zhaw/pa_fs25/util/SwissTransactionMapperTest.kt
@@ -1,0 +1,60 @@
+package ch.zhaw.pa_fs25.util
+
+import ch.zhaw.pa_fs25.data.entity.Category
+import ch.zhaw.pa_fs25.data.model.SwissTransaction
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+class SwissTransactionMapperTest {
+    private val sdf = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+
+    @Test
+    fun `map converts swiss transaction correctly`() {
+        val tx = SwissTransaction(
+            transactionId = "1",
+            bookingDate = "2024-05-01",
+            transactionAmount = SwissTransaction.Amount(amount = "12.50", currency = "CHF"),
+            creditorName = "Coop",
+            remittanceInformationUnstructured = null
+        )
+
+        val categories = listOf(
+            Category(id = 1, name = "Miscellaneous"),
+            Category(id = 2, name = "Groceries/Supermarkets", keywords = "coop")
+        )
+
+        val mapped = SwissTransactionMapper.map(tx, categories, 1)
+
+        assertEquals("Coop", mapped.description)
+        assertEquals(12.50, mapped.amount, 0.001)
+        assertEquals(sdf.parse("2024-05-01"), mapped.date)
+        assertEquals(2, mapped.categoryId)
+        assertEquals("Income", mapped.type)
+    }
+
+    @Test
+    fun `map uses remittance info and sets expense type`() {
+        val tx = SwissTransaction(
+            transactionId = "2",
+            bookingDate = "2024-05-02",
+            transactionAmount = SwissTransaction.Amount(amount = "-5.00", currency = "CHF"),
+            creditorName = "ignored",
+            remittanceInformationUnstructured = "Coffee Shop"
+        )
+
+        val categories = listOf(
+            Category(id = 1, name = "Miscellaneous"),
+            Category(id = 3, name = "Restaurants/Dining", keywords = "coffee")
+        )
+
+        val mapped = SwissTransactionMapper.map(tx, categories, 1)
+
+        assertEquals("Coffee Shop", mapped.description)
+        assertEquals(-5.00, mapped.amount, 0.001)
+        assertEquals(sdf.parse("2024-05-02"), mapped.date)
+        assertEquals(3, mapped.categoryId)
+        assertEquals("Expense", mapped.type)
+    }
+}

--- a/app/src/test/java/ch/zhaw/pa_fs25/util/TransactionsCategorizerTest.kt
+++ b/app/src/test/java/ch/zhaw/pa_fs25/util/TransactionsCategorizerTest.kt
@@ -1,0 +1,43 @@
+package ch.zhaw.pa_fs25.util
+
+import ch.zhaw.pa_fs25.data.entity.Category
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TransactionsCategorizerTest {
+    @Test
+    fun `categorizeTransaction matches keywords`() {
+        val category = TransactionsCategorizer.categorizeTransaction("Spent at Coop store")
+        assertEquals("Groceries/Supermarkets", category)
+    }
+
+    @Test
+    fun `categorizeTransaction returns Miscellaneous when no match`() {
+        val category = TransactionsCategorizer.categorizeTransaction("Random thing")
+        assertEquals("Miscellaneous", category)
+    }
+
+    @Test
+    fun `categorizeTransactions groups by category`() {
+        val result = TransactionsCategorizer.categorizeTransactions(listOf("Coop purchase", "Bus ticket"))
+        assertEquals(2, result.size)
+        assertEquals(listOf("Coop purchase"), result["Groceries/Supermarkets"])
+    }
+
+    @Test
+    fun `detectCategoryId returns category id for keyword`() {
+        val categories = listOf(
+            Category(id = 1, name = "Miscellaneous"),
+            Category(id = 2, name = "Groceries/Supermarkets", keywords = "coop")
+        )
+        val id = TransactionsCategorizer.detectCategoryId("Coop City", categories, 1, type = "Expense")
+        assertEquals(2, id)
+    }
+
+    @Test
+    fun `detectCategoryId falls back to default for income`() {
+        val categories = listOf(Category(id = 1, name = "Miscellaneous"))
+        val id = TransactionsCategorizer.detectCategoryId("Salary", categories, 1, type = "Income")
+        assertEquals(1, id)
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for `CategoryExtensions`
- test `TransactionsCategorizer`
- add tests for `SwissTransactionMapper`
- cover negative amounts and remittance information handling
